### PR TITLE
Improve Spring REST and GraphQL error handling

### DIFF
--- a/src/main/java/dev/thev1ndu/bookq/controller/BookController.java
+++ b/src/main/java/dev/thev1ndu/bookq/controller/BookController.java
@@ -4,6 +4,9 @@ import dev.thev1ndu.bookq.model.Book;
 import dev.thev1ndu.bookq.service.BookService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,6 +17,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class BookController {
     private final BookService bookService;
+    private static final Logger log = LoggerFactory.getLogger(BookController.class);
 
     @GetMapping
     public List<Book> findAll() {
@@ -28,13 +32,15 @@ public class BookController {
     }
 
     @PostMapping
-    public Book createBook(@Valid @RequestBody Book book) {
-        return bookService.createBook(book);
+    public ResponseEntity<Book> createBook(@Valid @RequestBody Book book) {
+        Book created = bookService.createBook(book);
+        return ResponseEntity.status(HttpStatus.CREATED).body(created);
     }
 
     @PutMapping("/{id}")
-    public Book updateBook(@PathVariable Long id, @Valid @RequestBody Book book) {
-        return bookService.updateBook(id, book);
+    public ResponseEntity<Book> updateBook(@PathVariable Long id, @Valid @RequestBody Book book) {
+        Book updated = bookService.updateBook(id, book);
+        return ResponseEntity.ok(updated);
     }
 
     @DeleteMapping("/{id}")

--- a/src/main/java/dev/thev1ndu/bookq/exception/BookNotFoundException.java
+++ b/src/main/java/dev/thev1ndu/bookq/exception/BookNotFoundException.java
@@ -1,0 +1,16 @@
+package dev.thev1ndu.bookq.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+/**
+ * Exception thrown when a Book entity cannot be found.
+ */
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class BookNotFoundException extends RuntimeException {
+
+    public BookNotFoundException(Long id) {
+        super("Book with id " + id + " not found");
+    }
+}
+

--- a/src/main/java/dev/thev1ndu/bookq/graphql/BookMutationResolver.java
+++ b/src/main/java/dev/thev1ndu/bookq/graphql/BookMutationResolver.java
@@ -1,14 +1,18 @@
 package dev.thev1ndu.bookq.graphql;
 
 import com.coxautodev.graphql.tools.GraphQLMutationResolver;
+import dev.thev1ndu.bookq.exception.BookNotFoundException;
 import dev.thev1ndu.bookq.model.Book;
 import dev.thev1ndu.bookq.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class BookMutationResolver implements GraphQLMutationResolver {
+    private static final Logger log = LoggerFactory.getLogger(BookMutationResolver.class);
     private final BookRepository bookRepository;
 
 //    POST
@@ -16,26 +20,28 @@ public class BookMutationResolver implements GraphQLMutationResolver {
         try {
             return bookRepository.save(new Book(title, author));
         } catch (Exception e) {
-            System.out.println("Error saving book: " + e.getMessage());
-            return null;
+            log.error("Error saving book", e);
+            throw e;
         }
     }
 
     //    PUT
     public Book updateBook(Long id, String title, String author) {
-        return bookRepository.findById(id).map(book -> {
-            book.setTitle(title);
-            book.setAuthor(author);
-            return bookRepository.save(book);
-        }).orElse(null);
+        return bookRepository.findById(id)
+                .map(book -> {
+                    book.setTitle(title);
+                    book.setAuthor(author);
+                    return bookRepository.save(book);
+                })
+                .orElseThrow(() -> new BookNotFoundException(id));
     }
 
 //    DEL
     public boolean deleteBook(Long id) {
-        if (bookRepository.existsById(id)) {
-            bookRepository.deleteById(id);
-            return true;
+        if (!bookRepository.existsById(id)) {
+            throw new BookNotFoundException(id);
         }
-        return false;
+        bookRepository.deleteById(id);
+        return true;
     }
 }

--- a/src/main/java/dev/thev1ndu/bookq/graphql/BookQueryResolver.java
+++ b/src/main/java/dev/thev1ndu/bookq/graphql/BookQueryResolver.java
@@ -4,6 +4,8 @@ import com.coxautodev.graphql.tools.GraphQLQueryResolver;
 import dev.thev1ndu.bookq.model.Book;
 import dev.thev1ndu.bookq.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -11,7 +13,8 @@ import java.util.List;
 @Component
 @RequiredArgsConstructor
 public class BookQueryResolver implements GraphQLQueryResolver {
-    private BookRepository bookRepository;
+    private static final Logger log = LoggerFactory.getLogger(BookQueryResolver.class);
+    private final BookRepository bookRepository;
 
     public List<Book> books() {
         return bookRepository.findAll();

--- a/src/main/java/dev/thev1ndu/bookq/service/BookService.java
+++ b/src/main/java/dev/thev1ndu/bookq/service/BookService.java
@@ -1,8 +1,11 @@
 package dev.thev1ndu.bookq.service;
 
+import dev.thev1ndu.bookq.exception.BookNotFoundException;
 import dev.thev1ndu.bookq.model.Book;
 import dev.thev1ndu.bookq.repository.BookRepository;
 import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -12,6 +15,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class BookService {
     private final BookRepository bookRepository;
+    private static final Logger log = LoggerFactory.getLogger(BookService.class);
 
     public List<Book> getAllBooks() {
         return bookRepository.findAll();
@@ -26,15 +30,24 @@ public class BookService {
     }
 
     public Book updateBook(Long id, Book updatedBook) {
+        if (updatedBook == null) {
+            log.warn("Attempted to update a book with null payload");
+            throw new IllegalArgumentException("Book body must not be null");
+        }
+
         return bookRepository.findById(id)
                 .map(existingBook -> {
                     existingBook.setTitle(updatedBook.getTitle());
                     existingBook.setAuthor(updatedBook.getAuthor());
                     return bookRepository.save(existingBook);
-                }).orElseThrow(() -> new RuntimeException("Book not found"));
+                })
+                .orElseThrow(() -> new BookNotFoundException(id));
     }
 
     public void deleteBook(Long id) {
+        if (!bookRepository.existsById(id)) {
+            throw new BookNotFoundException(id);
+        }
         bookRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
## Summary
- add `BookNotFoundException` to centralize missing entity error handling
- improve update & delete logic in `BookService`
- return ResponseEntity with correct status codes in `BookController`
- fix injection in `BookQueryResolver`
- log and validate mutations in `BookMutationResolver`

## Testing
- `./mvnw -q -DskipTests compile` *(fails: Failed to fetch dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686df4634fcc83209eba753799740695